### PR TITLE
feat: add gitleaksignore

### DIFF
--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -1,1 +1,7 @@
+48e844601d70759829b33a533e2cc51b2db60d73:components/Delegate/TokenAddress.jsx:generic-api-key:155
+8027bd54b5e9197ec4acf78443e030b87e61e81a:components/Delegate/TokenAddress.jsx:generic-api-key:152
+8027bd54b5e9197ec4acf78443e030b87e61e81a:components/Delegate/TokenAddress.jsx:generic-api-key:164
+48e844601d70759829b33a533e2cc51b2db60d73:components/Delegate/TokenAddress.jsx:generic-api-key:167
+f4dcad77e91d381bef474747a9d4f6242e7c58c6:components/Delegate/TokenAddress.jsx:generic-api-key:122
+f4dcad77e91d381bef474747a9d4f6242e7c58c6:components/Delegate/TokenAddress.jsx:generic-api-key:134
 f4dcad77e91d381bef474747a9d4f6242e7c58c6:components/Delegate/TokenAddress.jsx:generic-api-key:28


### PR DESCRIPTION
* Out of 7, only one seems to be the secret key, and as per @dvilelaf's suggestion added that to ignore.
